### PR TITLE
Fix multiple `git-rm-merged` targets.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,6 @@ test-force:
 cov:
 	uv run pytest --cov=gf180
 
-
-git-rm-merged:
-	git branch -D `git branch --merged | grep -v \* | xargs`
-
 update:
 	pur
 


### PR DESCRIPTION
Fixes the following output;
```
Makefile:32: warning: overriding recipe for target 'git-rm-merged'
Makefile:23: warning: ignoring old recipe for target 'git-rm-merged'
```

## Summary by Sourcery

Bug Fixes:
- Remove duplicate `git-rm-merged` target to prevent Makefile warnings.