### PR TITLE
A bunch of small fixes

### DIFF
--- a/docs/notebooks/intro.py
+++ b/docs/notebooks/intro.py
@@ -17,11 +17,11 @@
 # # Layout (DEPRECATED)
 #
 # > **DEPRECATION NOTICE**: The `gf180` package is deprecated and will be removed in a future version. Please use the `gf180mcu` package instead.
-# > 
+# >
 # > This notebook is kept for reference only and may contain outdated information.
 # >
 # > **Please visit the [gf180mcu documentation](https://gdsfactory.github.io/gf180mcu/) for up-to-date notebooks.**
-# 
+#
 # ## Layout driven flow using gf180mcu (recommended)
 #
 # You should import the PDK from gf180mcu and layout any of the standard cells
@@ -41,7 +41,7 @@ c.plot()
 
 # %%
 # Legacy/deprecated approach (generates deprecation warning)
-import gf180
+import gf180  # noqa
 
 # This still works but is redirected to gf180mcu internally
 c = gf180.diode_dw2ps()

--- a/docs/write_cells.py
+++ b/docs/write_cells.py
@@ -1,10 +1,8 @@
 import inspect
 import pathlib
 
-from gdsfactory.serialization import clean_value_json
-
 # Import directly from gf180mcu since gf180 is now just a wrapper
-import gf180mcu
+from gdsfactory.serialization import clean_value_json
 from gf180mcu import cells
 
 filepath = pathlib.Path(__file__).parent.absolute() / "cells.rst"
@@ -74,7 +72,7 @@ Cells
 
    This component documentation is deprecated.
    Please use the equivalent component in the gf180mcu package.
-   
+
    See the equivalent component in gf180mcu documentation:
    `gf180mcu.{name} <https://gdsfactory.github.io/gf180mcu/autoapi/gf180mcu/index.html#{name}>`_
 

--- a/gf180/__init__.py
+++ b/gf180/__init__.py
@@ -4,9 +4,7 @@ This module is a legacy/deprecated alias for the gf180mcu library.
 Please use gf180mcu directly in new code.
 """
 
-import sys
 import warnings
-import os
 
 # Show a deprecation warning when the module is imported
 warnings.warn(
@@ -16,10 +14,10 @@ warnings.warn(
     stacklevel=2,
 )
 
-import gf180mcu
+import gf180mcu  # noqa
 
 # Re-export everything from gf180mcu
-from gf180mcu import *
+from gf180mcu import *  # noqa
 
 # Re-export specific items to ensure compatibility
 __version__ = gf180mcu.__version__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ classifiers = [
   "Operating System :: OS Independent"
 ]
 dependencies = [
-  "gdsfactory~=9.2.0",
   "gf180mcu"
 ]
 description = "GlobalFoundries 180nm MCU"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,3 @@ regex = '''
   \.
   (?P<patch>\d+)
   '''
-
-[tool.uv.sources]
-gf180mcu = {path = "../gf180mcu"}


### PR DESCRIPTION
* The `gf180` module doesn't depend on gdsfactory directly (as it only depends on gf180mcu). Fixes issues like;
   ```
     ╰─▶ Because only gf180mcu==0.2.0 is available and gf180mcu==0.2.0 depends on gdsfactory>=9.7.0,<9.8.dev0, we can conclude that all versions of gf180mcu depend
         on gdsfactory>=9.7.0,<9.8.dev0.
         And because your project depends on gdsfactory>=9.2.0,<9.3.dev0, we can conclude that your project and all versions of gf180mcu are incompatible.
         And because your project depends on gf180mcu and your project requires gf180[dev], we can conclude that your project's requirements are unsatisfiable.
   ```
* Remove the uv source specifying gf180mcu locally. Fixes;
   ```
   error: Distribution not found at: file:///home/runner/work/gf180/gf180mcu
   ```
* Fixes the precommit errors found @ https://github.com/gdsfactory/gf180/actions/runs/15288418866/job/43003290194

## Summary by Sourcery

Fix dependency conflicts by removing direct gdsfactory requirement and local UV source, and address pre-commit lint and formatting issues across documentation and code.

Bug Fixes:
- Remove gdsfactory dependency from gf180’s pyproject.toml to resolve version incompatibilities.
- Remove the invalid local UV source entry for gf180mcu to prevent distribution-not-found errors.
- Clean up formatting in notebooks and scripts (trailing whitespace, blank lines) to satisfy pre-commit checks.

Enhancements:
- Add `# noqa` annotations to suppress lint errors on gf180’s re-exports and notebook imports.

Documentation:
- Adjust deprecation notice formatting in the intro notebook for consistency.